### PR TITLE
add target release attribute in Bug

### DIFF
--- a/src/main/java/org/jboss/pull/shared/Bug.java
+++ b/src/main/java/org/jboss/pull/shared/Bug.java
@@ -48,13 +48,14 @@ public class Bug implements Serializable{
     private Map<String, Object> bugMap;
 
     //includes attributes for Bug.get execution
-    public static final Object[] include_fields = {"id", "assigned_to", "status", "flags", "blocks"};
+    public static final Object[] include_fields = {"id", "assigned_to", "status", "flags", "blocks", "target_release"};
 
     private int id;
     private String assignedTo;
     private Status status;
     private List<Flag> flags;
     private Set<Integer> blocks;
+    private Set<String> targetRelease;
 
     public Bug(Map<String, Object> bugMap) {
         this.bugMap = bugMap;
@@ -95,6 +96,12 @@ public class Bug implements Serializable{
         blocks = new HashSet<Integer>(blockObjs.length);
         for (Object obj : blockObjs) {
             blocks.add((Integer) obj);
+        }
+
+        Object[] targetReleaseObjs = (Object[]) bugMap.get("target_release");
+        targetRelease = new HashSet<String>(targetReleaseObjs.length);
+        for (Object obj : targetReleaseObjs) {
+            targetRelease.add((String) obj);
         }
     }
 
@@ -144,6 +151,10 @@ public class Bug implements Serializable{
 
     public void setBlocks(Set<Integer> blocks) {
         this.blocks = blocks;
+    }
+
+    public Set<String> getTargetRelease() {
+        return targetRelease;
     }
 
 }

--- a/src/main/java/org/jboss/pull/shared/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/Bugzilla.java
@@ -60,10 +60,8 @@ public class Bugzilla {
             rpcClient.setConfig(config);
             return rpcClient;
         } catch (MalformedURLException e) {
-            System.err.println("Can not get XmlRpcClient from " + baseURL);
-            e.printStackTrace();
+            throw new RuntimeException("Can not get XmlRpcClient from " + baseURL);
         }
-        return null;
     }
 
     /**
@@ -87,27 +85,25 @@ public class Bugzilla {
 
         XmlRpcClient rpcClient = getClient();
 
-        if (rpcClient != null) {
-            try {
-                Object resultObj = rpcClient.execute("Bug.get", objs);
-                @SuppressWarnings("unchecked")
-                Map<Object, Object> resultMap = (Map<Object, Object>) resultObj;
+        try {
+            Object resultObj = rpcClient.execute("Bug.get", objs);
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> resultMap = (Map<Object, Object>) resultObj;
 
-                Object[] bugs = (Object[]) resultMap.get("bugs");
-                if (bugs.length == 1) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, Object> bugMap = (Map<String, Object>) bugs[0];
-                    Bug bug = new Bug(bugMap);
-                    return bug;
-                } else {
-                    throw new XmlRpcException("Zero or more than one bug found with id: " + bugzillaId);
-                }
-            } catch (XmlRpcException e) {
-                System.err.println("Can not get bug with id : " + bugzillaId);
-                e.printStackTrace(System.err);
-            } finally {
-                rpcClient = null;
+            Object[] bugs = (Object[]) resultMap.get("bugs");
+            if (bugs.length == 1) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> bugMap = (Map<String, Object>) bugs[0];
+                Bug bug = new Bug(bugMap);
+                return bug;
+            } else {
+                throw new RuntimeException("Zero or more than one bug found with id: " + bugzillaId);
             }
+        } catch (XmlRpcException e) {
+            System.err.println("Can not get bug with id : " + bugzillaId);
+            e.printStackTrace(System.err);
+        } finally {
+            rpcClient = null;
         }
         return null;
     }
@@ -155,19 +151,17 @@ public class Bugzilla {
         Object[] objParams = { params };
 
         XmlRpcClient rpcClient = getClient();
-        if (rpcClient != null) {
-            try {
+        try {
 
-                Object resultObj = rpcClient.execute("Bug.update", objParams);
-                @SuppressWarnings("unchecked")
-                Map<Object, Object> resultMap = (Map<Object, Object>) resultObj;
-                int id = (Integer) resultMap.get("id");
-                return id == bugzillaId;
-            } catch (XmlRpcException e) {
-                e.printStackTrace();
-            } finally {
-                rpcClient = null;
-            }
+            Object resultObj = rpcClient.execute("Bug.update", objParams);
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> resultMap = (Map<Object, Object>) resultObj;
+            int id = (Integer) resultMap.get("id");
+            return id == bugzillaId;
+        } catch (XmlRpcException e) {
+            e.printStackTrace();
+        } finally {
+            rpcClient = null;
         }
         return false;
     }
@@ -204,15 +198,13 @@ public class Bugzilla {
 
         XmlRpcClient rpcClient = getClient();
 
-        if (rpcClient != null) {
-            try {
-                rpcClient.execute("Flag.update", objs);
-                return true;
-            } catch (XmlRpcException e) {
-                e.printStackTrace();
-            } finally {
-                rpcClient = null;
-            }
+        try {
+            rpcClient.execute("Flag.update", objs);
+            return true;
+        } catch (XmlRpcException e) {
+            e.printStackTrace();
+        } finally {
+            rpcClient = null;
         }
         return false;
     }

--- a/src/main/java/org/jboss/pull/shared/Flag.java
+++ b/src/main/java/org/jboss/pull/shared/Flag.java
@@ -23,7 +23,7 @@ package org.jboss.pull.shared;
 
 import java.io.Serializable;
 
-public class Flag implements Serializable{
+public class Flag implements Serializable {
 
     private static final long serialVersionUID = -4167575539988047120L;
 
@@ -85,6 +85,24 @@ public class Flag implements Serializable{
 
     public String toString() {
         return setter + "\t" + " set " + name + "\t" + " to " + status + "\t\n";
+    }
+
+    public String getConvertedFlag() {
+        String convertedFlag = " "; // default is UNSET
+        switch (status) {
+            case POSITIVE:
+                convertedFlag = "+";
+                break;
+            case NEGATIVE:
+                convertedFlag = "-";
+                break;
+            case UNKNOWN:
+                convertedFlag = "?";
+                break;
+            default:
+                break;
+        }
+        return convertedFlag;
     }
 
 }

--- a/src/main/java/org/jboss/pull/shared/evaluators/BasePullEvaluator.java
+++ b/src/main/java/org/jboss/pull/shared/evaluators/BasePullEvaluator.java
@@ -37,12 +37,16 @@ import java.util.Properties;
 public abstract class BasePullEvaluator implements PullEvaluator {
     public static final String EVALUATOR_PROPERTY = "evaluator";
     public static final String GITHUB_BRANCH_PROPERTY = "github.branch";
+    public static final String GITHUB_ORGANIZAITON_UPSTREAM = "github.organization.upstream";
+    public static final String GITHUB_REPOSITORY_UPSTREAM = "github.repo.upstream";
 
     protected PullHelper helper;
 //    protected Properties configuration;
 
     protected String version;
     protected String githubBranch;
+    protected String upstreamOrganization;
+    protected String upstreamRepository;
 
     @Override
     public void init(final PullHelper helper, final Properties configuration, final String version) {
@@ -50,6 +54,13 @@ public abstract class BasePullEvaluator implements PullEvaluator {
 //        this.configuration = configuration;
         this.version = version;
         this.githubBranch = Util.require(configuration, version + "." + GITHUB_BRANCH_PROPERTY);
+        this.upstreamOrganization = Util.require(configuration, version + "." + GITHUB_ORGANIZAITON_UPSTREAM);
+        this.upstreamRepository = Util.require(configuration, version + "." + GITHUB_REPOSITORY_UPSTREAM);
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
     }
 
     @Override
@@ -57,6 +68,15 @@ public abstract class BasePullEvaluator implements PullEvaluator {
         return githubBranch;
     }
 
+    @Override
+    public String getUpstreamOrganization() {
+        return upstreamOrganization;
+    }
+
+    @Override
+    public String getUpstreamRepository() {
+        return upstreamRepository;
+    }
 
     protected Result isMergeableByUpstream(final PullRequest pull) {
         final Result mergeable = new Result(true);

--- a/src/main/java/org/jboss/pull/shared/evaluators/FlagBasedPullEvaluator.java
+++ b/src/main/java/org/jboss/pull/shared/evaluators/FlagBasedPullEvaluator.java
@@ -76,7 +76,7 @@ public class FlagBasedPullEvaluator extends BasePullEvaluator {
     protected Result isMergeableByBugzilla(final PullRequest pull) {
         final Result mergeable = new Result(true);
 
-        final List<Bug> bugs = helper.getBug(pull);
+        final List<Bug> bugs = helper.getBug(pull, version);
         if (bugs.isEmpty()) {
             mergeable.setMergeable(false);
             mergeable.addDescription("- Missing any bugzilla bug");

--- a/src/main/java/org/jboss/pull/shared/evaluators/ParentBugBasedPullEvaluator.java
+++ b/src/main/java/org/jboss/pull/shared/evaluators/ParentBugBasedPullEvaluator.java
@@ -65,7 +65,7 @@ public class ParentBugBasedPullEvaluator extends BasePullEvaluator {
     protected Result isMergeableByBugzilla(final PullRequest pull) {
         final Result mergeable = new Result(false);
 
-        final List<Bug> bugs = helper.getBug(pull);
+        final List<Bug> bugs = helper.getBug(pull, version);
         if (bugs.isEmpty()) {
             mergeable.addDescription("- Missing any bugzilla bug");
             return mergeable;

--- a/src/main/java/org/jboss/pull/shared/evaluators/PullEvaluatorUtil.java
+++ b/src/main/java/org/jboss/pull/shared/evaluators/PullEvaluatorUtil.java
@@ -72,13 +72,18 @@ public class PullEvaluatorUtil {
     }
 
     public PullEvaluator.Result isMergeable(final PullRequest pull) {
-        final String targetBranch = pull.getBase().getRef();
-        final PullEvaluator evaluator = evaluators.get(targetBranch);
+        PullEvaluator evaluator = getPullEvaluator(pull);
+        return evaluator.isMergeable(pull);
+    }
+
+    public PullEvaluator getPullEvaluator(final PullRequest pull) {
+        String targetBranch = pull.getBase().getRef();
+        PullEvaluator evaluator = evaluators.get(targetBranch);
 
         if (evaluator == null)
             throw new IllegalStateException("Couldn't find any evaluator for target github branch " + targetBranch);
 
-        return evaluator.isMergeable(pull);
+        return evaluator;
     }
 
     public Set<String> getCoveredBranches() {

--- a/src/main/java/org/jboss/pull/shared/spi/PullEvaluator.java
+++ b/src/main/java/org/jboss/pull/shared/spi/PullEvaluator.java
@@ -50,6 +50,10 @@ public interface PullEvaluator {
      */
     String getTargetBranch();
 
+    String getUpstreamOrganization();
+    String getUpstreamRepository();
+    String getVersion();
+
     /**
      * Evaluates if the given pull request is mergeable according to
      * the rules of the relevant EAP version.


### PR DESCRIPTION
add target release attribute in Bug, add specified upstream organization/repository for different PRs

(due to PR descriptions redundant information: both wildfly and 6.x upstream PRs, both 6.2.x and 6.3.x Bz. we only collect correct upstream PRs and BZs base on upstream organization/repository,  current version and target release).
relocate regexp patterns from pull-processor Processor to shared part
allow to get converted flag value like "+, - ?" to friendly display
better exception catches in Bugzilla.
