### PR TITLE
Fixing error in refactoring.

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/github/GithubHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/github/GithubHelper.java
@@ -185,7 +185,7 @@ public class GithubHelper {
 
         for (Comment comment : comments) {
             Matcher matcher = pattern.matcher(comment.getBody());
-            if(matcher.matches()){
+            if(matcher.find()){
                 lastComment = comment;
             }
         }


### PR DESCRIPTION
matcher.matches() only works if the entire string matches the pattern. 

Needed to use matcher.find() to locate a match within the string.
