### PR TITLE
Implementing Processor-Complainer

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/jira/JiraHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/jira/JiraHelper.java
@@ -1,0 +1,18 @@
+package org.jboss.pull.shared.connectors.jira;
+
+public class JiraHelper {
+
+    public JiraHelper(final String configurationFileProperty, final String configurationFileDefault) throws Exception {
+        try {
+
+        } catch (Exception e) {
+            System.err.printf("Cannot initialize: %s\n", e);
+            e.printStackTrace(System.err);
+            throw e;
+        }
+    }
+
+    public JiraIssue getJIRA() {
+        return null;
+    }
+}


### PR DESCRIPTION
Parses github PR description for a BZ or JIRA link and complains if one is not found.

Parses github PR description for a PR link, assumed to be upstream, or 'no upstream required' pattern. Complains if not found.

Doesn't re-complain if the complaint has not changed. Does not post anything if there are no complaints.
