### PR TITLE
Removing RuntimeException throw from getBug method

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -76,6 +76,11 @@ public class Bugzilla {
         return params;
     }
 
+    /**
+     * Gets the bugId from bugzilla.
+     * @param bugzillaId
+     * @return - Bug retrieved from Bugzilla, or null if no bug was found.
+     */
     public Bug getBug(Integer bugzillaId) {
         Map<Object, Object> params = getParameterMap();
         params.put("include_fields", Bug.include_fields);
@@ -97,7 +102,7 @@ public class Bugzilla {
                 Bug bug = new Bug(bugMap);
                 return bug;
             } else {
-                throw new RuntimeException("Zero or more than one bug found with id: " + bugzillaId);
+                System.out.println("Zero or more than one bug found with id: " + bugzillaId);
             }
         } catch (XmlRpcException e) {
             System.err.println("Can not get bug with id : " + bugzillaId);


### PR DESCRIPTION
Should simply return null if no bug is found.

Upstream: https://github.com/jboss-set/pull-shared/pull/47
