### PR TITLE
#50 - Added TestNG dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,13 @@
             <artifactId>xmlrpc-client</artifactId>
             <version>${xmlrpc-client.version}</version>
         </dependency>
+
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>6.8.7</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Version 6.8.7 which was released in Sept. 2013. There is a 6.8.8 which was released in Feb 2014, but it's not in the Red Hat repo, and I doubt there's much of a difference for our use case.
