### PR TITLE
Enabled 'upstream' match using commit link instead of PR link.

### DIFF
--- a/src/main/java/org/jboss/pull/shared/Constants.java
+++ b/src/main/java/org/jboss/pull/shared/Constants.java
@@ -62,8 +62,8 @@ public class Constants {
 
     // 'Related PR' should also match on commit link
     // * https://github.com/jbossas/jboss-eap/commit/4c7b374e3960791ed4cd4f0cf9a02c38b0bf7d62
-//    public static final Pattern COMMIT_RELATED_PR_PATTERN = Pattern.compile(
-//            ".*github\\.com.*?/([a-zA-Z_0-9-]*)/([a-zA-Z_0-9-]*)/commit/([a-zA-Z_0-9-]*)", Pattern.CASE_INSENSITIVE);
+    public static final Pattern COMMIT_RELATED_PR_PATTERN = Pattern.compile(
+            ".*github\\.com.*?/([a-zA-Z_0-9-]*)/([a-zA-Z_0-9-]*)/commit/([a-zA-Z_0-9-]*)", Pattern.CASE_INSENSITIVE);
 
     // URL bases
     public static final String BUGZILLA_BASE = "https://bugzilla.redhat.com/";

--- a/src/main/java/org/jboss/pull/shared/connectors/RedhatPullRequest.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/RedhatPullRequest.java
@@ -165,6 +165,10 @@ public class RedhatPullRequest {
             retVal = true;
         }
 
+        if (Constants.COMMIT_RELATED_PR_PATTERN.matcher(getGithubDescription()).find()) {
+            retVal = true;
+        }
+
         return retVal;
     }
 
@@ -343,6 +347,7 @@ public class RedhatPullRequest {
     public void addLabel(Label newLabel) {
         ghHelper.addLabel(pullRequest, newLabel);
     }
+
     public void removeLabel(Label newLabel) {
         ghHelper.removeLabel(pullRequest, newLabel);
     }


### PR DESCRIPTION
Close #57
