### PR TITLE
Release 0.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.jboss.jbossset</groupId>
 	<artifactId>pull-shared</artifactId>
-	<version>0.4-SNAPSHOT</version>
+    <version>0.4.0.Final</version>
 	<packaging>jar</packaging>
 	<name>Pull Shared</name>
 

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
@@ -32,6 +32,7 @@ import java.util.SortedSet;
 import org.jboss.pull.shared.Constants;
 import org.jboss.pull.shared.Util;
 import org.jboss.pull.shared.connectors.IssueHelper;
+import org.jboss.pull.shared.connectors.bugzilla.Bugzilla.CommentVisibility;
 import org.jboss.pull.shared.connectors.common.AbstractCommonIssueHelper;
 import org.jboss.pull.shared.connectors.common.Issue;
 
@@ -89,5 +90,9 @@ public class BZHelper extends AbstractCommonIssueHelper implements IssueHelper {
 
     public Map<String, Bug> loadIssues(Set<String> bugIds) throws IllegalArgumentException {
         return bugzillaClient.getBugs(bugIds);
+    }
+
+    public boolean addComment(final int id, final String text, CommentVisibility visibility, double worktime) {
+        return bugzillaClient.addComment(id, text, visibility, worktime);
     }
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
@@ -23,13 +23,14 @@
 package org.jboss.pull.shared.connectors.bugzilla;
 
 
+import java.net.URL;
+import java.util.SortedSet;
+
 import org.jboss.pull.shared.Constants;
 import org.jboss.pull.shared.Util;
 import org.jboss.pull.shared.connectors.IssueHelper;
 import org.jboss.pull.shared.connectors.common.AbstractCommonIssueHelper;
 import org.jboss.pull.shared.connectors.common.Issue;
-
-import java.net.URL;
 
 public class BZHelper extends AbstractCommonIssueHelper implements IssueHelper {
 
@@ -73,5 +74,9 @@ public class BZHelper extends AbstractCommonIssueHelper implements IssueHelper {
         String urlStr = url.toString().trim().toLowerCase();
         int index = urlStr.indexOf("id=");
         return Integer.parseInt(urlStr.substring(index + 3));
+    }
+
+    public SortedSet<Comment> loadCommentsFor(Bug bug) throws IllegalArgumentException {
+        return bugzillaClient.commentsFor(bug);
     }
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
@@ -24,6 +24,9 @@ package org.jboss.pull.shared.connectors.bugzilla;
 
 
 import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 
 import org.jboss.pull.shared.Constants;
@@ -78,5 +81,13 @@ public class BZHelper extends AbstractCommonIssueHelper implements IssueHelper {
 
     public SortedSet<Comment> loadCommentsFor(Bug bug) throws IllegalArgumentException {
         return bugzillaClient.commentsFor(bug);
+    }
+
+    public Map<String, SortedSet<Comment>> loadCommentsFor(Collection<String> bugIds) throws IllegalArgumentException {
+        return bugzillaClient.commentsFor(bugIds);
+    }
+
+    public Map<String, Bug> loadIssues(Set<String> bugIds) throws IllegalArgumentException {
+        return bugzillaClient.getBugs(bugIds);
     }
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
@@ -37,7 +37,35 @@ public class Bug implements Issue {
 
     // Bug Status
     public enum Status {
-        NEW, ASSIGNED, POST, MODIFIED, ON_DEV, ON_QA, VERIFIED, RELEASE_PENDING, CLOSED
+        NEW(0,"NEW"), ASSIGNED(1,"ASSIGNED"), POST(2,"POST"), MODIFIED(3,"MODIFIED"), ON_DEV(4,"ON_DEV"), ON_QA(5,"ON_QA"), VERIFIED(6,"VERIFIED"), RELEASE_PENDING(7,"RELEASE_PENDING"), CLOSED(8,"CLOSED");
+
+        private final int step;
+        private final String label;
+
+        private Status(final int step, final String label) {
+            this.step = step;
+            this.label = label.toUpperCase();
+        }
+
+        public boolean hasPullRequest() {
+            return ( step >= POST.step );
+        }
+
+        public boolean isAbove(Status status) {
+            return ( step > status.step );
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+        public Status fromLabel(String label) {
+            for ( Status status : Status.values() ) {
+                if ( status.label.equalsIgnoreCase(label))
+                    return status;
+            }
+            throw new IllegalArgumentException("No instance of " + Status.class + " associated with label:" + label);
+        }
     }
 
     private static final long serialVersionUID = 6967220126171894474L;

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
@@ -298,4 +298,14 @@ public class Bug implements Issue {
         return targetRelease;
     }
 
+
+    @Override
+    public String toString() {
+        return "Bug [id=" + id + ", alias=" + alias + ", product=" + product + ", component=" + component + ", version="
+                + version + ", priority=" + priority + ", severity=" + severity + ", targetMilestone=" + targetMilestone
+                + ", creator=" + creator + ", assignedTo=" + assignedTo + ", qaContact=" + qaContact + ", docsContact="
+                + docsContact + ", status=" + status + ", resolution=" + resolution + ", flags=" + flags + ", groups=" + groups
+                + ", dependsOn=" + dependsOn + ", blocks=" + blocks + ", targetRelease=" + targetRelease + ", summary="
+                + summary + ", description=" + description + ", url=" + url + ", type=" + type + "]";
+    }
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
@@ -73,7 +73,7 @@ public class Bug implements Issue {
     // includes attributes for Bug.get execution
     public static final Object[] include_fields = { "id", "alias", "product", "component", "version", "priority", "severity",
             "target_milestone", "creator", "assigned_to", "qa_contact", "docs_contact", "status", "resolution", "flags",
-            "groups", "depends_on", "blocks", "target_release", "summary", "description" };
+            "groups", "depends_on", "blocks", "target_release", "summary", "description", "cf_type" };
 
     private int id;
     private List<String> alias;
@@ -97,6 +97,7 @@ public class Bug implements Issue {
     private String summary;
     private String description;
     private URL url;        // The issue URL.
+    private String type;
 
     public Bug(Map<String, Object> bugMap) {
         id = (Integer) bugMap.get("id");
@@ -182,6 +183,8 @@ public class Bug implements Issue {
 
         summary = (String) bugMap.get("summary");
         description = (String) bugMap.get("description");
+
+        type = (String) bugMap.get("cf_type");
 
         try {
             this.url = new URL("https://bugzilla.redhat.com/show_bug.cgi?id=" + id);
@@ -279,6 +282,10 @@ public class Bug implements Issue {
     @Override
     public String getNumber() {
         return Integer.toString(id);
+    }
+
+    public String getType() {
+        return type;
     }
 
     @Override

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -33,6 +33,7 @@ import java.util.TreeSet;
 
 import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
+import org.apache.xmlrpc.client.XmlRpcClientConfig;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import org.jboss.pull.shared.connectors.common.Flag.Status;
 
@@ -54,19 +55,20 @@ public class Bugzilla {
      * @return XmlRpcClient
      */
     private XmlRpcClient getClient() {
-        try {
-            String apiURL = baseURL + "xmlrpc.cgi";
-            XmlRpcClient rpcClient;
-            XmlRpcClientConfigImpl config;
-            config = new XmlRpcClientConfigImpl();
-            config.setServerURL(new URL(apiURL));
-            rpcClient = new XmlRpcClient();
-            rpcClient.setConfig(config);
-            return rpcClient;
-        } catch (MalformedURLException e) {
-            throw new RuntimeException("Can not get XmlRpcClient from " + baseURL);
-        }
+        String apiURL = baseURL + "xmlrpc.cgi";
+        XmlRpcClient rpcClient;
+        rpcClient = new XmlRpcClient();
+        rpcClient.setConfig(getClientConfig(createURL(apiURL)));
+        return rpcClient;
     }
+
+    private XmlRpcClientConfig getClientConfig(URL apiURL) {
+        XmlRpcClientConfigImpl config;
+        config = new XmlRpcClientConfigImpl();
+        config.setServerURL(apiURL);
+        return config;
+    }
+
 
     /**
      * Get an initialized parameter map with login and password

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -82,6 +82,15 @@ public class Bugzilla {
         return params;
     }
 
+
+    private URL createURL(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Can not get XmlRpcClient from " + baseURL, e);
+        }
+    }
+
     /**
      * Gets the bugId from bugzilla.
      *

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -303,20 +303,25 @@ public class Bugzilla {
 
         Map<Object, Object> params = getParameterMap();
         params.put("ids", turnIdIntoAnArray(bug.getId()));
-        Map<Object, Object> results = fetchData("Bug.comments", turnMapIntoObjectArray(params));
+        Map<Object, Object> results = fetchData(METHOD_BUG_COMMENTS, turnMapIntoObjectArray(params));
 
         if (results != null && !results.isEmpty() && results.containsKey("bugs")) {
             Map<String, Object> bugs = (Map<String, Object>) results.get("bugs");
-            Map<String, Object[]> comments = (Map<String, Object[]>) bugs.get(String.valueOf(bug.getId()));
-            SortedSet<Comment> bugComments = new TreeSet<Comment>();
-            for (Object[] allComments : comments.values()) {
-                for (Object comment : allComments) {
-                    bugComments.add(new Comment((Map<String, Object>) comment));
-                }
-            }
-            return bugComments;
+            return buildComments((Map<String, Object[]>) bugs.get(String.valueOf(bug.getId())));
         }
         return new TreeSet<Comment>();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private SortedSet<Comment> buildComments(Map<String, Object[]> comments) {
+        SortedSet<Comment> bugComments = new TreeSet<Comment>();
+        for (Object[] allComments : comments.values()) {
+            for (Object comment : allComments) {
+                bugComments.add(new Comment((Map<String, Object>) comment));
+            }
+        }
+        return bugComments;
     }
 
     @SuppressWarnings("unchecked")
@@ -377,7 +382,7 @@ public class Bugzilla {
     private String[] turnToStringArray(Set<String> set) {
         String[] strings = new String[set.size()];
         int i = 0;
-        for ( String string : set ) {
+        for (String string : set) {
             strings[i++] = string;
         }
         return strings;

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -87,7 +87,6 @@ public class Bugzilla {
         return params;
     }
 
-
     private URL createURL(String url) {
         try {
             return new URL(url);

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bugzilla.java
@@ -47,6 +47,7 @@ public class Bugzilla {
     private static final String METHOD_FLAG_UPDATE = "Flag.update";
     private static final String METHOD_BUG_GET = "Bug.get";
     private static final String METHOD_BUG_COMMENTS = "Bug.comments";
+    private static final String METHOD_BUG_ADD_COMMENT = "Bug.add_comment";
 
     public Bugzilla(String serverUrl, String login, String password) {
         this.baseURL = serverUrl;
@@ -318,7 +319,32 @@ public class Bugzilla {
             }
         }
         return results;
+    }
 
+    public enum CommentVisibility {
+
+        PUBLIC(false), PRIVATE(true);
+
+        private boolean visibility;
+
+        CommentVisibility(final boolean visibility){
+            this.visibility = visibility;
+        }
+
+        public boolean isPrivate() { return visibility; }
+
+    }
+
+    public boolean addComment(final int id, final String text, final CommentVisibility visibility, final double worktime) {
+
+        Map<Object, Object> params = getParameterMap();
+        params.put("id", id);
+        params.put("comment", text);
+        params.put("private", visibility.isPrivate());
+        params.put("work_time", worktime);
+        Object[] objs = { params };
+
+        return runCommand(METHOD_BUG_ADD_COMMENT, objs);
     }
 
     private String[] turnToStringArray(Set<String> set) {

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Comment.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Comment.java
@@ -1,0 +1,169 @@
+package org.jboss.pull.shared.connectors.bugzilla;
+
+import java.util.Date;
+import java.util.Map;
+
+public class Comment implements Comparable<Comment> {
+
+    public static final int ID = 0;
+    public static final int AUTHOR = 1;
+    public static final int TEXT = 2;
+    public static final int TIME = 3;
+    public static final int COUNT = 4;
+    public static final int CREATION_TIME = 5;
+    public static final int IS_PRIVATE = 6;
+    public static final int BUG_ID = 7;
+    public static final int CREATOR_ID = 8;
+    public static final int CREATOR = 9;
+
+    public static final Object[] include_fields = { "id", "author", "text", "time", "count", "creation_time", "is_private",
+            "bug_id", "creator_id", "creator" };
+
+    private int id;
+    private String author;
+    private String text;
+    private Date time;
+    private int count;
+    private Date creationTime;
+    private boolean visibility; // can name the variable 'public' or private !
+    private int bugId;
+    private int creatorId;
+    private String creator;
+
+    public Comment(Map<String, Object> commentMap) {
+        id = (Integer) commentMap.get(include_fields[ID]);
+        author = (String) commentMap.get(include_fields[AUTHOR]);
+        text = (String) commentMap.get(include_fields[TEXT]);
+        time = (Date) commentMap.get(include_fields[TIME]);
+        count = (Integer) commentMap.get(include_fields[COUNT]);
+        creationTime = (Date) commentMap.get(include_fields[CREATION_TIME]);
+        visibility = (Boolean) commentMap.get(include_fields[IS_PRIVATE]);
+        bugId = (Integer) commentMap.get(include_fields[BUG_ID]);
+        creatorId = (Integer) commentMap.get(include_fields[CREATOR_ID]);
+        creator = (String) commentMap.get(include_fields[CREATOR]);
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Date getTime() {
+        return time;
+    }
+
+    public void setTime(Date time) {
+        this.time = time;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public Date getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(Date creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public boolean isPrivate() {
+        return visibility;
+    }
+
+    public void setPrivate(boolean visibility) {
+        this.visibility = visibility;
+    }
+
+    public int getBugId() {
+        return bugId;
+    }
+
+    public void setBugId(int bugId) {
+        this.bugId = bugId;
+    }
+
+    public int getCreatorId() {
+        return creatorId;
+    }
+
+    public void setCreatorId(int creatorId) {
+        this.creatorId = creatorId;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    @Override
+    public String toString() {
+        return "Comment [id=" + id + ", author=" + author + ", text=" + text + ", time=" + time + ", count=" + count
+                + ", creationTime=" + creationTime + ", visibility=" + visibility + ", bugId=" + bugId + ", creatorId="
+                + creatorId + ", creator=" + creator + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((author == null) ? 0 : author.hashCode());
+        result = prime * result + bugId;
+        result = prime * result + count;
+        result = prime * result + ((creationTime == null) ? 0 : creationTime.hashCode());
+        result = prime * result + ((creator == null) ? 0 : creator.hashCode());
+        result = prime * result + creatorId;
+        result = prime * result + id;
+        result = prime * result + ((text == null) ? 0 : text.hashCode());
+        result = prime * result + ((time == null) ? 0 : time.hashCode());
+        result = prime * result + (visibility ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( obj instanceof Comment ) {
+            return ( this.getId() == ((Comment)obj).getId() ? true : false);
+        }
+        return false;
+    }
+
+    @Override
+    public int compareTo(Comment o) {
+        if ( o == null )
+            throw new IllegalArgumentException("Can't compare instance of comment [ID:" + o.getId() + "] with a 'null' instance of Comment !");
+        if (this.getBugId() != o.getBugId() )
+            throw new IllegalArgumentException("Can't compare comment [" + "BugId:" + o.getBugId() + " that does not belong to the same issue [BugId:" + this.getBugId());
+        if ( this.getCount() == o.getCount())
+            return 0;
+        return this.getCount() > o.getCount() ? 1 : -1;
+    }
+
+}


### PR DESCRIPTION
# Changelog
* Add a method to add a comment to a BZ
* whitespaces
* Code cleanig - unifies calls to XML-RPC client and removes redundant code
* Code cleaning - add private method to reduce size/complexity
* Add handy method to encapsulate URL exception
* Code cleaning - enhance getClient()
* Add a getBugs() method
* Add method to retrieve comments from a Bug
* Bug: add toString()
* Add 'Type' fields to Bug
* - Red Hat has a custom fields named Type classifying the nature of the fix.
* BZ Status Enum reworked
* - enhance the enum to support building one from a String, but also compare them to find out which if the status instance is 'in front' or 'behind', in term of worklow.
