### PR TITLE
Retrieve information on external tracker associted to bug instance - if any

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Bug.java
@@ -29,6 +29,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,10 +47,10 @@ public class Bug implements Issue {
     private static final long serialVersionUID = 6967220126171894474L;
 
     // includes attributes for Bug.get execution
-    public static final Object[] include_fields = { "id", "alias", "last_change_time" , "product", "component", "version", "priority",
-            "severity", "target_milestone", "creator", "assigned_to", "qa_contact", "docs_contact", "status", "resolution",
-            "flags", "groups", "depends_on", "blocks", "target_release", "summary", "description", "cf_type", "creation_time",
-            "estimated_time", "actual_time", "remaining_time" };
+    public static final Object[] include_fields = { "id", "alias", "last_change_time", "product", "component", "version",
+            "priority", "severity", "target_milestone", "creator", "assigned_to", "qa_contact", "docs_contact", "status",
+            "resolution", "flags", "groups", "depends_on", "blocks", "target_release", "summary", "description", "cf_type",
+            "creation_time", "estimated_time", "actual_time", "remaining_time", "external_bugs" };
 
     private int id;
     private List<String> alias;
@@ -80,11 +81,13 @@ public class Bug implements Issue {
     private Double actual_time;
     private Double remaining_time;
 
+    private Set<ExternalTrackerReference> externalTrackerRefs = new HashSet<ExternalTrackerReference>(0);
+
+    @SuppressWarnings("unchecked")
     public Bug(Map<String, Object> bugMap) {
         id = (Integer) bugMap.get("id");
 
         alias = convertIntoStringList((Object[]) bugMap.get("alias"));
-
         last_change_time = (Date) bugMap.get("last_change_time");
 
         product = (String) bugMap.get("product");
@@ -123,6 +126,11 @@ public class Bug implements Issue {
         estimated_time = (Double) bugMap.get("estimated_time");
         actual_time = (Double) bugMap.get("actual_time");
         remaining_time = (Double) bugMap.get("remaining_time");
+
+        Object[] external_bugs = (Object[]) bugMap.get("external_bugs");
+        if (external_bugs != null && external_bugs.length > 0)
+            for (Object o : external_bugs)
+                externalTrackerRefs.add(new ExternalTrackerReference((Map<String, Object>) o));
 
         setUrl(id);
     }
@@ -305,14 +313,13 @@ public class Bug implements Issue {
 
     @Override
     public String toString() {
-        return "Bug [id=" + id + ", last_change_time=" + last_change_time + ", alias=" + alias + ", product=" + product + ", component=" + component + ", version="
-                + version + ", priority=" + priority + ", severity=" + severity + ", targetMilestone=" + targetMilestone
-                + ", creator=" + creator + ", assignedTo=" + assignedTo + ", qaContact=" + qaContact + ", docsContact="
-                + docsContact + ", status=" + status + ", resolution=" + resolution + ", flags=" + flags + ", groups=" + groups
-                + ", dependsOn=" + dependsOn + ", blocks=" + blocks + ", targetRelease=" + targetRelease + ", summary="
-                + summary + ", description=" + description + ", url=" + url + ", type=" + type + ", creationTime="
-                + creationTime + ", estimated_time" + estimated_time + "]" + ", actual_time" + actual_time + "]"
-                + ", remaining_time" + remaining_time + "]";
+        return "Bug [id=" + id + ", alias=" + alias + ", last_change_time=" + last_change_time + ", product=" + product
+                + ", component=" + component + ", version=" + version + ", priority=" + priority + ", severity=" + severity
+                + ", targetMilestone=" + targetMilestone + ", creator=" + creator + ", assignedTo=" + assignedTo
+                + ", qaContact=" + qaContact + ", docsContact=" + docsContact + ", status=" + status + ", resolution="
+                + resolution + ", flags=" + flags + ", groups=" + groups + ", dependsOn=" + dependsOn + ", blocks=" + blocks
+                + ", targetRelease=" + targetRelease + ", summary=" + summary + ", description=" + description + ", url=" + url
+                + ", type=" + type + ", creationTime=" + creationTime + ", estimated_time=" + estimated_time + ", actual_time="
+                + actual_time + ", remaining_time=" + remaining_time + ", externalTrackerRefs=" + externalTrackerRefs + "]";
     }
-
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/ExternalTrackerReference.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/ExternalTrackerReference.java
@@ -1,0 +1,58 @@
+package org.jboss.pull.shared.connectors.bugzilla;
+
+import java.util.Map;
+
+public class ExternalTrackerReference {
+
+    private final  int id ;
+    private final  int trackerId ;
+    private final  String bugId ;
+    private final  String priority ;
+    private final  String description ;
+    private final  TrackerType trackerType ;
+    private final  String status;
+
+    public ExternalTrackerReference(Map<String, Object> map) {
+        this.id = (Integer) map.get("id");
+        this.trackerId = (Integer) map.get("ext_bz_id");
+        this.bugId = (String) map.get("ext_bz_bug_id");
+        this.priority= (String) map.get("ext_priority");
+        this.description = (String) map.get("ext_description");
+        this.trackerType = new TrackerType((Map<String,Object>)map.get("type"));
+        this.status = (String) map.get("ext_status");
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getTrackerId() {
+        return trackerId;
+    }
+
+    public String getBugId() {
+        return bugId;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public TrackerType getTrackerType() {
+        return trackerType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalTrackerReference [id=" + id + ", trackerId=" + trackerId + ", bugId=" + bugId + ", priority="
+                + priority + ", description=" + description + ", trackerType=" + trackerType + ", status=" + status + "]";
+    }
+}

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/TrackerType.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/TrackerType.java
@@ -1,0 +1,64 @@
+package org.jboss.pull.shared.connectors.bugzilla;
+
+import java.util.Map;
+
+public class TrackerType {
+
+    private final int id;
+    private final boolean mustSend;
+    private final boolean sendOnce;
+    private final boolean canSend;
+    private final String description;
+    private final boolean canGet;
+    private final String fullUrl;
+    private final String url;
+
+    public TrackerType(Map<String, Object> map) {
+        this.id = (Integer) map.get("id");
+        this.mustSend = (Boolean) map.get("must_send");
+        this.sendOnce = (Boolean) map.get("send_once");
+        this.canSend = (Boolean) map.get("can_send");
+        this.description = (String) map.get("description");
+        this.canGet = (Boolean) map.get("can_get");
+        this.fullUrl = (String) map.get("fullUrl");
+        this.url = (String) map.get("url");
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public boolean isMustSend() {
+        return mustSend;
+    }
+
+    public boolean isSendOnce() {
+        return sendOnce;
+    }
+
+    public boolean isCanSend() {
+        return canSend;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isCanGet() {
+        return canGet;
+    }
+
+    public String getFullUrl() {
+        return fullUrl;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public String toString() {
+        return "TrackerType [id=" + id + ", mustSend=" + mustSend + ", sendOnce=" + sendOnce + ", canSend=" + canSend
+                + ", description=" + description + ", canGet=" + canGet + ", fullUrl=" + fullUrl + ", url=" + url + "]";
+    }
+}


### PR DESCRIPTION
When retrieving infos on BZ, Pull Shared is currently *not* retrieving any info related to external tracker. After thorough testing last month, I've realized the amount of information retrieve when calling BugZilla API on a bug has little impact on performance - thus retrieving only the ID or every tidbit of information is as performant (meaning as "slow"). 

In this context, I don't think it's a bad idea to retrieve those extra information, that will allow BugClerk to produce rules around those metadata.