### PR TITLE
Enhance Pull Shared API for Bugzilla

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BZHelper.java
@@ -94,4 +94,8 @@ public class BZHelper extends AbstractCommonIssueHelper implements IssueHelper {
     public boolean addComment(final int id, final String text, CommentVisibility visibility, double worktime) {
         return bugzillaClient.addComment(id, text, visibility, worktime);
     }
+
+    public boolean updateEstimate(final int id, final double worktime) {
+        return bugzillaClient.updateEstimate(id, worktime);
+    }
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
@@ -78,6 +78,16 @@ public class BugsClient extends AbstractBugzillaClient {
         return runCommand(METHOD_BUG_UPDATE, params);
     }
 
+
+    public boolean updateEstimate(int id, double worktime) {
+        Map<String, Object> params = getParameterMap();
+        params.put("ids", id);
+        params.put("estimated_time", worktime);
+
+        return runCommand("Bug.update", params);
+    }
+
+
     @SuppressWarnings("unchecked")
     public Map<String, Bug> getBugs(Set<String> keySet) {
         if (keySet == null || keySet.isEmpty())

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
@@ -111,4 +111,8 @@ public class BugsClient extends AbstractBugzillaClient {
         return results;
     }
 
+    public boolean customOperation(String methodname, Map<String,Object> params) {
+        params.putAll(getParameterMap());
+        return runCommand(methodname, params);
+    }
 }


### PR DESCRIPTION
* add a couple of method to update the time estimate associated to a BZ
* add a generic method allowing external programs (such as scripts) to create their own query, rather than being limited by the one provided by the current API