### PR TITLE
Refactor/Error Handling in IssueHelper Proposal

### DIFF
--- a/src/main/java/org/jboss/pull/shared/connectors/IssueHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/IssueHelper.java
@@ -22,14 +22,23 @@
 
 package org.jboss.pull.shared.connectors;
 
-import org.jboss.pull.shared.connectors.common.Issue;
-
 import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.pull.shared.connectors.common.Issue;
 
 /**
  * @author navssurtani
  */
-public interface IssueHelper {
+public interface IssueHelper<T extends Issue> {
+    /**
+     * A method to test if underlying implementatio accepts a given issue.n.
+     *
+     * @param url - the issue URL
+     * @return - whether or not the url is accepted by the underlying issue tracking system.
+     */
+    boolean accepts(URL url);
 
     /**
      * Finds a given {@link Issue} based on a URL parameter. Any client should make sure that
@@ -40,16 +49,7 @@ public interface IssueHelper {
      * @throws java.lang.IllegalArgumentException - if the String is incorrect. This will be if the remote server
      * rejects the request.
      */
-    Issue findIssue(URL url) throws IllegalArgumentException;
-
-
-    /**
-     * A method to test if underlying implementatio accepts a given issue.n.
-     *
-     * @param url - the issue URL
-     * @return - whether or not the url is accepted by the underlying issue tracking system.
-     */
-    boolean accepts(URL url);
+    T findIssue(URL url) throws IllegalArgumentException, IssueUnavailableException;
 
     /**
      * Update the status ofan {@link Issue}e. Before calling this method, {@link #accepts(java.net.URL)} should be called
@@ -58,4 +58,25 @@ public interface IssueHelper {
      * @return - whether or not the status was updated successfully.
      */
     boolean updateStatus(URL url, Enum status);
+
+    /**
+     * Chechk whether the description contains a link that this issue tracker can hanler or not.
+     * @param description content of the description
+     * @return wheter or not there is at least one link to this issue tracker
+     */
+    boolean hasLinkInDescription(String description);
+
+    /**
+     * extracts the url contained in the description
+     * @param description description of the issue
+     * @return a list of url to this issue tracker
+     */
+    List<URL> extractURLs(String description);
+
+    /**
+     * initialize the issue tracker
+     * @param props properties to initilize the issue tracker
+     * @throws Exception
+     */
+    void init(Properties props) throws Exception;
 }

--- a/src/main/java/org/jboss/pull/shared/connectors/IssueUnavailableException.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/IssueUnavailableException.java
@@ -1,0 +1,15 @@
+package org.jboss.pull.shared.connectors;
+
+public class IssueUnavailableException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public IssueUnavailableException(String msg) {
+       super(msg);
+    }
+
+    public IssueUnavailableException(String msg, Throwable th) {
+        super(msg, th);
+    }
+
+}

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/BugsClient.java
@@ -87,8 +87,6 @@ public class BugsClient extends AbstractBugzillaClient {
         return runCommand("Bug.update", params);
     }
 
-
-    @SuppressWarnings("unchecked")
     public Map<String, Bug> getBugs(Set<String> keySet) {
         if (keySet == null || keySet.isEmpty())
             throw new IllegalArgumentException("Provided bug instance can't be null or empty");

--- a/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Comment.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/bugzilla/Comment.java
@@ -158,7 +158,7 @@ public class Comment implements Comparable<Comment> {
     @Override
     public int compareTo(Comment o) {
         if ( o == null )
-            throw new IllegalArgumentException("Can't compare instance of comment [ID:" + o.getId() + "] with a 'null' instance of Comment !");
+            throw new IllegalArgumentException("Can't compare instance of comment [ID:" + this.getId() + "] with a 'null' instance of Comment !");
         if (this.getBugId() != o.getBugId() )
             throw new IllegalArgumentException("Can't compare comment [" + "BugId:" + o.getBugId() + " that does not belong to the same issue [BugId:" + this.getBugId());
         if ( this.getCount() == o.getCount())

--- a/src/main/java/org/jboss/pull/shared/connectors/common/AbstractCommonIssueHelper.java
+++ b/src/main/java/org/jboss/pull/shared/connectors/common/AbstractCommonIssueHelper.java
@@ -22,32 +22,48 @@
 
 package org.jboss.pull.shared.connectors.common;
 
-import org.jboss.pull.shared.Util;
-import org.jboss.pull.shared.connectors.IssueHelper;
-
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author navssurtani
  */
 
-public abstract class AbstractCommonIssueHelper implements IssueHelper {
+public abstract class AbstractCommonIssueHelper {
 
-    protected Properties fromUtil;
+    private Properties properties;
 
-    public AbstractCommonIssueHelper(final String configurationFileProperty,
-                                     final String configurationFileDefault) throws Exception {
 
-        // We just want to initialise the properties here.
-        try {
-            this.fromUtil = Util.loadProperties(configurationFileProperty, configurationFileDefault);
-        } catch (Exception e) {
-            System.err.printf("Cannot initialize: %s\n", e);
-            e.printStackTrace(System.err);
-            throw e;
-        }
-
+    public void init(Properties properties) throws Exception {
+        this.properties = properties;
+        init();
     }
 
+    public abstract void init() throws Exception;
+
+
+    public final Properties getProperties() {
+        return properties;
+    }
+
+    protected final List<URL> extractURLs(String urlBase, Pattern toMatch, String content) {
+        final List<URL> urls = new ArrayList<URL>();
+        final Matcher matcher = toMatch.matcher(content);
+        while (matcher.find()) {
+            try {
+                urls.add(new URL(urlBase + matcher.group(1)));
+            } catch (NumberFormatException ignore) {
+                System.err.printf("Invalid bug number: %s.\n", ignore);
+            } catch (MalformedURLException malformed) {
+                System.err.printf("Invalid URL formed: %s. \n", malformed);
+            }
+        }
+        return urls;
+    }
 
 }

--- a/src/main/resources/META-INF/services/org.jboss.pull.shared.connectors.IssueHelper
+++ b/src/main/resources/META-INF/services/org.jboss.pull.shared.connectors.IssueHelper
@@ -1,0 +1,2 @@
+org.jboss.pull.shared.connectors.bugzilla.BZHelper
+org.jboss.pull.shared.connectors.jira.JiraHelper

--- a/src/test/java/org/jboss/shared/connectors/jira/JiraIssueTest.java
+++ b/src/test/java/org/jboss/shared/connectors/jira/JiraIssueTest.java
@@ -22,6 +22,7 @@
 
 package org.jboss.shared.connectors.jira;
 
+import org.jboss.pull.shared.Util;
 import org.jboss.pull.shared.connectors.IssueHelper;
 import org.jboss.pull.shared.connectors.common.Flag;
 import org.jboss.pull.shared.connectors.jira.JiraHelper;
@@ -48,14 +49,15 @@ public class JiraIssueTest {
     private static final String BASE_FILE_NAME = "./processor-eap-6.properties.example";
     private static final String JIRA_URL_BASE = "https://issues.jboss.org/browse/";
 
-    private IssueHelper jiraHelper = null;
+    private IssueHelper<?> jiraHelper = null;
 
 
     @BeforeTest
     public void startHelper() throws Exception {
         // Because the Util class looks for system properties.
         System.setProperty(BASE_FILE_PROPERTY, BASE_FILE_NAME);
-        this.jiraHelper = new JiraHelper(BASE_FILE_PROPERTY, BASE_FILE_NAME);
+        this.jiraHelper = new JiraHelper();
+        this.jiraHelper.init(Util.loadProperties(BASE_FILE_PROPERTY, BASE_FILE_NAME));
     }
 
     @AfterTest


### PR DESCRIPTION
Remove coupling problems in issue helpers 
   # using ServiceLoader. PullHelper does not need to know about 
     helper impl details
   # moving url extraction to the issue helper (it is responsability of
     the helper to know how to extract an url from text
   # moving has Issue linked to the issue helper (again it is
     responsability of the issue helper to know if there is an url)
   # Improve a bit the error handling when the issue is not accessible

Small improvement with label service cache. Too many requests to the label service.
(this avoids stop processing whenever there is a a network problem with the issue tracker)
